### PR TITLE
刷新开局库，清理原列表

### DIFF
--- a/VinXiangQi/OpenBookSettingsForm.cs
+++ b/VinXiangQi/OpenBookSettingsForm.cs
@@ -64,6 +64,7 @@ namespace VinXiangQi
         private void button_refresh_Click(object sender, EventArgs e)
         {
             Mainform.InitOpenBooks();
+            listBox_openbook_list.Items.Clear();
             foreach (var book in Mainform.OpenBookList)
             {
                 listBox_openbook_list.Items.Add(book.Key);


### PR DESCRIPTION
修复刷新开局库，原列表不会清除，重复叠加的问题